### PR TITLE
update: リポジトリ移管作業のための更新漏れ箇所を追加修正

### DIFF
--- a/FLOW/02_experimental_phase/base_monitor_dataset_structure.ipynb
+++ b/FLOW/02_experimental_phase/base_monitor_dataset_structure.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "ここでは、作成いただいたデータセット（実験リポジトリ）の構成状態をモニタリングします。以下のセルを実行することで、それぞれのデータセットがその管理品質上、適合的であるかどうかを確認できます。モニタリングの結果はREADME.mdへ自動的に反映されます。\n",
     "\n",
-    "![result_on_README](https://raw.githubusercontent.com/ivis-kuwata/workflow-template/main/images/result_on_README.png)\n",
+    "![result_on_README](https://raw.githubusercontent.com/NII-DG/workflow-template/main/images/result_on_README.png)\n",
     "\n",
     "## ◇◆◇開発メモ◇◆◇\n",
     "\n",

--- a/FLOW/base_FLOW.ipynb
+++ b/FLOW/base_FLOW.ipynb
@@ -43,7 +43,7 @@
     "次のフェーズに進む前に必ず実行する必要があります。  \n",
     "ワークフロー機能を使うのが初めての場合は、「初期セットアップを行う」、「起動毎に必要な準備を行う」の順に実行してください。  \n",
     "2回目以降でワークフロー機能にREADMEのリンクからではなく、以下のmaDMP実行環境への遷移ボタンから遷移した場合は、ワークフロー機能を実行する前に「起動毎に必要な準備を行う」を実行してください。  \n",
-    "![maDMP実行ボタン](https://raw.githubusercontent.com/ivis-kuwata/workflow-template/develop/sections/images/maDMP実行ボタン.png)"
+    "![maDMP実行ボタン](https://raw.githubusercontent.com/NII-DG/workflow-template/develop/sections/images/maDMP実行ボタン.png)"
    ]
   },
   {

--- a/FLOW/base_FLOW.ipynb
+++ b/FLOW/base_FLOW.ipynb
@@ -43,7 +43,7 @@
     "次のフェーズに進む前に必ず実行する必要があります。  \n",
     "ワークフロー機能を使うのが初めての場合は、「初期セットアップを行う」、「起動毎に必要な準備を行う」の順に実行してください。  \n",
     "2回目以降でワークフロー機能にREADMEのリンクからではなく、以下のmaDMP実行環境への遷移ボタンから遷移した場合は、ワークフロー機能を実行する前に「起動毎に必要な準備を行う」を実行してください。  \n",
-    "![maDMP実行ボタン](https://raw.githubusercontent.com/NII-DG/workflow-template/develop/sections/images/maDMP実行ボタン.png)"
+    "![maDMP実行ボタン](https://raw.githubusercontent.com/NII-DG/workflow-template/main/images/maDMP実行ボタン.png)"
    ]
   },
   {

--- a/FLOW/util/base_finish_research.ipynb
+++ b/FLOW/util/base_finish_research.ipynb
@@ -48,7 +48,7 @@
     "\n",
     "[コントロールパネル](https://jupyter.cs.rcos.nii.ac.jp/hub/home)へ遷移して、`1.1`で確認したサーバーを`stop`、`delete`ボタンをクリックして停止・削除してください。  \n",
     "※`delete`ボタンは、以下の図のように`stop`ボタンをクリックした後に表示されます。  \n",
-    "![コンテナ削除キャプチャ](https://raw.githubusercontent.com/NII-DG/workflow-template/develop/sections/PACKAGE/EX-WORKFLOW/images/コンテナ削除キャプチャ.png)"
+    "![コンテナ削除キャプチャ](https://raw.githubusercontent.com/NII-DG/workflow-template/main/PACKAGE/EX-WORKFLOW/images/コンテナ削除キャプチャ.png)"
    ]
   }
  ],

--- a/FLOW/util/base_finish_research.ipynb
+++ b/FLOW/util/base_finish_research.ipynb
@@ -48,7 +48,7 @@
     "\n",
     "[コントロールパネル](https://jupyter.cs.rcos.nii.ac.jp/hub/home)へ遷移して、`1.1`で確認したサーバーを`stop`、`delete`ボタンをクリックして停止・削除してください。  \n",
     "※`delete`ボタンは、以下の図のように`stop`ボタンをクリックした後に表示されます。  \n",
-    "![コンテナ削除キャプチャ](https://raw.githubusercontent.com/ivis-kuwata/workflow-template/develop/sections/PACKAGE/EX-WORKFLOW/images/コンテナ削除キャプチャ.png)"
+    "![コンテナ削除キャプチャ](https://raw.githubusercontent.com/NII-DG/workflow-template/develop/sections/PACKAGE/EX-WORKFLOW/images/コンテナ削除キャプチャ.png)"
    ]
   }
  ],

--- a/FLOW/util/base_finish_research.ipynb
+++ b/FLOW/util/base_finish_research.ipynb
@@ -48,7 +48,7 @@
     "\n",
     "[コントロールパネル](https://jupyter.cs.rcos.nii.ac.jp/hub/home)へ遷移して、`1.1`で確認したサーバーを`stop`、`delete`ボタンをクリックして停止・削除してください。  \n",
     "※`delete`ボタンは、以下の図のように`stop`ボタンをクリックした後に表示されます。  \n",
-    "![コンテナ削除キャプチャ](https://raw.githubusercontent.com/NII-DG/workflow-template/main/PACKAGE/EX-WORKFLOW/images/コンテナ削除キャプチャ.png)"
+    "![コンテナ削除キャプチャ](https://raw.githubusercontent.com/NII-DG/workflow-template/main/PACKAGE/base/EX-WORKFLOW/images/コンテナ削除キャプチャ.png)"
    ]
   }
  ],


### PR DESCRIPTION
## やったこと

* Notebookにおける画像表示のための取得リンク先のリポジトリURLについて、移管後のものに置換した。

## やらないこと

* 無し。

## できるようになること（ユーザ目線）

* 無し。

## できなくなること（ユーザ目線）

* 無し。

## 動作確認の内容と結果

* 画像が正しく表示されることを確認した。

## その他

* 無し。