### PR TITLE
mdx接続先の動的設定／接続先のGPU有無に応じた制御導入

### DIFF
--- a/FLOW/01_preparation_phase/base_setup_data_analysis_tools.ipynb
+++ b/FLOW/01_preparation_phase/base_setup_data_analysis_tools.ipynb
@@ -23,9 +23,9 @@
     "tags": []
    },
    "source": [
-    "## 1. 高性能実験環境のアカウント情報の入力\n",
+    "## 1. 高性能実験環境への接続情報の入力\n",
     "\n",
-    "以下のセルを実行し、表示されるフォームに高性能実験環境におけるアカウント情報を入力してください。"
+    "以下のセルを実行し、表示されるフォームに高性能実験環境への接続情報を入力してください。"
    ]
   },
   {
@@ -36,6 +36,7 @@
    "source": [
     "from IPython.display import clear_output\n",
     "import getpass\n",
+    "ip_mdx = input(\"利用する高性能実験環境のIPアドレス：\")\n",
     "name_mdx = input(\"高性能実験環境におけるSSHユーザ名：\")\n",
     "clear_output()"
    ]
@@ -110,7 +111,7 @@
     "import os\n",
     "\n",
     "# mdx接続情報を設定ファイルに記述する\n",
-    "utils.config_mdx(name_mdx=name_mdx, mdxDomain=params['mdxDomain'])\n",
+    "utils.config_mdx(name_mdx=name_mdx, mdxDomain=ip_mdx)\n",
     "clear_output()"
    ]
   },
@@ -158,7 +159,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/FLOW/02_experimental_phase/base_launch_an_experiment.ipynb
+++ b/FLOW/02_experimental_phase/base_launch_an_experiment.ipynb
@@ -374,6 +374,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "高性能実験環境の接続先情報を取得します。以下のセルを実行してください。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mdx_host = ''\n",
+    "with open('/home/jovyan/.ssh/config', 'r') as f:\n",
+    "    tmp = f.read()\n",
+    "    tmp = tmp[tmp.find('mdx'):]\n",
+    "    tmp = tmp[tmp.find('Hostname ') + len('Hostname '):]\n",
+    "    mdx_host = tmp[:tmp.find('\\n')]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "高性能実験環境に実験パッケージ情報を転送します。以下のセルを実行してください。"
    ]
   },
@@ -409,7 +430,10 @@
     "clear_output()\n",
     "\n",
     "# JupyterLabコンテナの起動\n",
-    "cmd = \"docker run --gpus all -d -P dg/jupyterlab:1.1\"\n",
+    "if mdx_host == '163.220.176.51':\n",
+    "    cmd = \"docker run --gpus all -d -P dg/jupyterlab:1.1\"\n",
+    "else:\n",
+    "    cmd = \"docker run -d -P dg/jupyterlab:1.1\"\n",
     "container_id = !ssh mdx $cmd\n",
     "container_id = container_id[0][:12]\n",
     "\n",
@@ -450,7 +474,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/FLOW/02_experimental_phase/base_launch_an_experiment.ipynb
+++ b/FLOW/02_experimental_phase/base_launch_an_experiment.ipynb
@@ -444,7 +444,7 @@
     "port = port[port.find(\"0.0.0.0:\") + 8: port.find(\"->8888/tcp\")]\n",
     "\n",
     "# JupyterLab利用のためのURLを表示\n",
-    "url = \"http://\" + params['mdxDomain'] + \":\" + str(port) + \"/notebooks/experiment.ipynb\"\n",
+    "url = \"http://\" + mdx_host + \":\" + str(port) + \"/notebooks/experiment.ipynb\"\n",
     "print(url)"
    ]
   },

--- a/FLOW/param_files/params.json
+++ b/FLOW/param_files/params.json
@@ -6,7 +6,6 @@
         "gitHubSsh": "git@github.com:"
     },
     "rcosBinderUrl": "https://jupyter.cs.rcos.nii.ac.jp",
-    "mdxDomain": "163.220.176.51",
     "monitoring": {
         "dataAmount": {
             "name": "データ容量",


### PR DESCRIPTION
## やったこと

フィードバック管理表の以下の項目に関連する改善

* 項番61：mdx環境上のVMへのssh接続切り替え
* 項番65：GPUなし環境における実験コンテナ起動エラー

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* 利用するmdx環境のssh接続先を動的に設定できるようになる
* GPUなしの環境を指定した場合にも正常に動作するようになる

## できなくなること（ユーザ目線）

* 無し

## 動作確認の内容と結果

* 改修後のワークフローにて、動的にmdx環境接続先が切り替えられることを確認した
* その際、GPUの有無どちらの環境に対しても、正常にワークフローが動作することを確認した

## その他

* ssh接続先を動的に設定する構成としたため、FLOW/param_files/params.jsonのコンフィグ定義情報は削除した
