### PR TITLE
項番:38 「pipeline.jsonのリンクがあるが、クリックすると404エラーになる。」対応

### DIFF
--- a/FLOW/02_experimental_phase/base_monitor_reproducibility.ipynb
+++ b/FLOW/02_experimental_phase/base_monitor_reproducibility.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# モニタリング（再現性）\n",
     "\n",
-    "研究の再現性についてモニタリングします。モニタリングでは、[pipeline.json](../../../experiments.pipeline.json)に設定された順番に実験が再現されます。  \n",
+    "研究の再現性についてモニタリングします。モニタリングでは、[pipeline.json](../../../experiments/pipeline.json)に設定された順番に実験が再現されます。  \n",
     "以下のセルを上から実行してください。2回目以降の実行では、画面上部に表示される以下のボタンをクリックしてから実行して下さい。  \n",
     "![UnfreezeBotton](https://raw.githubusercontent.com/NII-DG/workflow-template/develop/sections/images/unfreeze_button.png)"
    ]


### PR DESCRIPTION
## やったこと

項番:38 「pipeline.jsonのリンクがあるが、クリックすると404エラーになる。」対応

## やらないこと

なし

## できるようになること（ユーザ目線）

404のリンクエラーが解消し、pipeline.jsonファイルの内容が確認できるようになった。

## できなくなること（ユーザ目線）

なし

## 動作確認の内容と結果

* どのような動作確認を行ったか
　→　該当ノートブックを、jyupiter上で動かし、リンクが正常にできることを確認する。

* その結果はどうだったか
　→　確認結果問題なし。

## その他
* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
　→　特になし。
