### PR TITLE
pipeline.json書き戻し漏れを修正

### DIFF
--- a/EX-WORKFLOWS/util/required_every_time.ipynb
+++ b/EX-WORKFLOWS/util/required_every_time.ipynb
@@ -441,6 +441,7 @@
     "save_path = []\n",
     "for file in files:\n",
     "    save_path.append(experiment_path + '/' + file)\n",
+    "save_path.append('/home/jovyan/pipeline.json')\n",
     "\n",
     "# Git-annex管理するパスの配列を作成する\n",
     "annexed_save_path = [experiment_path + '/input_data', experiment_path + '/output_data']"


### PR DESCRIPTION
## やったこと

pipeline.jsonが書き戻し対象外になっていたバグを修正した。

## やらないこと

* このプルリクでやらないことは何か（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか（あれば。無いなら「無し」でOK）

## 動作確認の内容と結果

pipeline.jsonもGINに保存されることを確認した。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
