### PR TITLE
書き戻し処理にdatalad updateを追加+競合解決FAQへのリンクを追記

### DIFF
--- a/EX-WORKFLOWS/enter_metadata.ipynb
+++ b/EX-WORKFLOWS/enter_metadata.ipynb
@@ -142,20 +142,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "以下を実行して、`リポジトリ側の変更と競合しました。競合を解決してください。`と表示された場合は、[こちらのFAQ](http://dg02.dg.rcos.nii.ac.jp/G-Node/Info/wiki/%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC#1-1%E5%90%8C%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E5%81%B4%E3%81%AE%E5%A4%89%E6%9B%B4%E3%81%A8%E7%AB%B6%E5%90%88%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E7%AB%B6%E5%90%88%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)を参考に競合を解決してください。"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "%cd ~/\n",
     "save_path = [experiment_path + '/meta_data.json', '/home/jovyan/WORKFLOWS/EX-WORKFLOWS/enter_metadata.ipynb']\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_メタデータ登録', IS_RECURSIVE = False, TO_GIT = True, PATH = save_path)\n",
-    ")"
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_メタデータ登録', IS_RECURSIVE = False, TO_GIT = True, PATH = save_path)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   },
   {

--- a/EX-WORKFLOWS/finish.ipynb
+++ b/EX-WORKFLOWS/finish.ipynb
@@ -94,20 +94,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import papermill as pm\n",
-    "\n",
-    "%cd ~/\n",
-    "# Git-annex管理ファイルを保存\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_実験終了 (1/2)', PATH = annexed_save_path, IS_RECURSIVE = False)\n",
-    ")"
+    "以下を実行して、`リポジトリ側の変更と競合しました。競合を解決してください。`と表示された場合は、[こちらのFAQ](http://dg02.dg.rcos.nii.ac.jp/G-Node/Info/wiki/%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC#1-1%E5%90%8C%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E5%81%B4%E3%81%AE%E5%A4%89%E6%9B%B4%E3%81%A8%E7%AB%B6%E5%90%88%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E7%AB%B6%E5%90%88%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)を参考に競合を解決してください。"
    ]
   },
   {
@@ -117,14 +107,49 @@
    "outputs": [],
    "source": [
     "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
+    "\n",
+    "%cd ~/\n",
+    "# Git-annex管理ファイルを保存\n",
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_実験終了 (1/2)', PATH = annexed_save_path, IS_RECURSIVE = False)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "%cd ~/\n",
     "# Git管理ファイルを保存\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_実験終了 (2/2)', TO_GIT = True, PATH = save_path, IS_RECURSIVE = False)\n",
-    ")"
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_実験終了 (2/2)', TO_GIT = True, PATH = save_path, IS_RECURSIVE = False)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   },
   {

--- a/EX-WORKFLOWS/prepare_input_data.ipynb
+++ b/EX-WORKFLOWS/prepare_input_data.ipynb
@@ -183,20 +183,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "以下を実行して、`リポジトリ側の変更と競合しました。競合を解決してください。`と表示された場合は、[こちらのFAQ](http://dg02.dg.rcos.nii.ac.jp/G-Node/Info/wiki/%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC#1-1%E5%90%8C%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E5%81%B4%E3%81%AE%E5%A4%89%E6%9B%B4%E3%81%A8%E7%AB%B6%E5%90%88%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E7%AB%B6%E5%90%88%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)を参考に競合を解決してください。"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "%cd ~/\n",
     "save_path = [ experiment_path + '/input_data/' + input_repo_title, '/home/jovyan/.gitmodules']\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_入力データの準備', PATH = save_path, IS_RECURSIVE = False)\n",
-    ")"
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_入力データの準備', PATH = save_path, IS_RECURSIVE = False)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   },
   {

--- a/EX-WORKFLOWS/save.ipynb
+++ b/EX-WORKFLOWS/save.ipynb
@@ -83,20 +83,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import papermill as pm\n",
-    "\n",
-    "%cd ~/\n",
-    "# Git-annex管理ファイルを保存\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_' + message + ' (1/2)', PATH = annexed_save_path, IS_RECURSIVE = False)\n",
-    ")"
+    "以下を実行して、`リポジトリ側の変更と競合しました。競合を解決してください。`と表示された場合は、[こちらのFAQ](http://dg02.dg.rcos.nii.ac.jp/G-Node/Info/wiki/%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC#1-1%E5%90%8C%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E5%81%B4%E3%81%AE%E5%A4%89%E6%9B%B4%E3%81%A8%E7%AB%B6%E5%90%88%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E7%AB%B6%E5%90%88%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)を参考に競合を解決してください。"
    ]
   },
   {
@@ -106,14 +96,49 @@
    "outputs": [],
    "source": [
     "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
+    "\n",
+    "%cd ~/\n",
+    "# Git-annex管理ファイルを保存\n",
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_' + message + ' (1/2)', PATH = annexed_save_path, IS_RECURSIVE = False)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "%cd ~/\n",
     "# Git管理ファイルを保存\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_' + message + ' (2/2)', TO_GIT = True, PATH = save_path, IS_RECURSIVE = False)\n",
-    ")"
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_' + message + ' (2/2)', TO_GIT = True, PATH = save_path, IS_RECURSIVE = False)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   },
   {

--- a/EX-WORKFLOWS/util/required_every_time.ipynb
+++ b/EX-WORKFLOWS/util/required_every_time.ipynb
@@ -448,6 +448,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e68c5d91",
+   "metadata": {},
+   "source": [
+    "以下を実行して、`リポジトリ側の変更と競合しました。競合を解決してください。`と表示された場合は、[こちらのFAQ](http://dg02.dg.rcos.nii.ac.jp/G-Node/Info/wiki/%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC#1-1%E5%90%8C%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E5%81%B4%E3%81%AE%E5%A4%89%E6%9B%B4%E3%81%A8%E7%AB%B6%E5%90%88%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E7%AB%B6%E5%90%88%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)を参考に競合を解決してください。"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "1a897dff",
@@ -455,14 +463,23 @@
    "outputs": [],
    "source": [
     "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "%cd ~/\n",
     "# Git-annex管理ファイルを保存\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_ワークフロー実行準備 (1/2)', PATH = annexed_save_path, IS_RECURSIVE = False)\n",
-    ")"
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_ワークフロー実行準備 (1/2)', PATH = annexed_save_path, IS_RECURSIVE = False)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   },
   {
@@ -473,14 +490,23 @@
    "outputs": [],
    "source": [
     "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "%cd ~/\n",
     "# Git管理ファイルを保存\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_ワークフロー実行準備 (2/2)', TO_GIT = True, PATH = save_path, IS_RECURSIVE = False)\n",
-    ")"
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/EX-WORKFLOWS/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = EXPERIMENT_TITLE + '_ワークフロー実行準備 (2/2)', TO_GIT = True, PATH = save_path, IS_RECURSIVE = False)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   },
   {

--- a/FLOW/02_experimental_phase/base_monitor_data_size.ipynb
+++ b/FLOW/02_experimental_phase/base_monitor_data_size.ipynb
@@ -180,20 +180,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "以下を実行して、`リポジトリ側の変更と競合しました。競合を解決してください。`と表示された場合は、[こちらのFAQ](http://dg02.dg.rcos.nii.ac.jp/G-Node/Info/wiki/%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC#1-1%E5%90%8C%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E5%81%B4%E3%81%AE%E5%A4%89%E6%9B%B4%E3%81%A8%E7%AB%B6%E5%90%88%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E7%AB%B6%E5%90%88%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)を参考に競合を解決してください。"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "%cd ~/\n",
-    "\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/FLOW/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = 'モニタリング（研究データ容量）', IS_RECURSIVE = False, TO_GIT = True)\n",
-    ")"
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/FLOW/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = 'モニタリング（研究データ容量）', IS_RECURSIVE = False, TO_GIT = True)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   },
   {

--- a/FLOW/02_experimental_phase/base_monitor_dataset_structure.ipynb
+++ b/FLOW/02_experimental_phase/base_monitor_dataset_structure.ipynb
@@ -124,20 +124,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "以下を実行して、`リポジトリ側の変更と競合しました。競合を解決してください。`と表示された場合は、[こちらのFAQ](http://dg02.dg.rcos.nii.ac.jp/G-Node/Info/wiki/%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC#1-1%E5%90%8C%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E5%81%B4%E3%81%AE%E5%A4%89%E6%9B%B4%E3%81%A8%E7%AB%B6%E5%90%88%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E7%AB%B6%E5%90%88%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)を参考に競合を解決してください。"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "%cd ~/\n",
-    "\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/FLOW/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters=dict(SAVE_MESSAGE='モニタリング（データセット構成）', IS_RECURSIVE=False, TO_GIT=True)\n",
-    ")\n"
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/FLOW/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters=dict(SAVE_MESSAGE='モニタリング（データセット構成）', IS_RECURSIVE=False, TO_GIT=True)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   }
  ],

--- a/FLOW/util/base_datalad_save_push.ipynb
+++ b/FLOW/util/base_datalad_save_push.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.書き戻しの準備を行う"
+    "## 1.変更内容を書き戻す"
    ]
   },
   {
@@ -42,27 +42,32 @@
    "outputs": [],
    "source": [
     "from datalad import api\n",
+    "import traceback\n",
     "\n",
-    "api.save(message=SAVE_MESSAGE, path=PATH, recursive=IS_RECURSIVE, to_git=TO_GIT)\n",
-    "api.unlock(PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 2.変更内容を書き戻す"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from datalad import api\n",
+    "DATALAD_MESSAGE = ''\n",
+    "DATALAD_ERROR = ''\n",
     "\n",
-    "api.push(to=SIBLING_NAME, result_renderer=RESULT_RENDERER, path=PATH, recursive=IS_RECURSIVE)"
+    "try:\n",
+    "    # Jupyter環境の変更をコミットしてから、リポジトリの更新内容をマージする\n",
+    "    api.save(message=SAVE_MESSAGE, path=PATH, recursive=IS_RECURSIVE, to_git=TO_GIT)\n",
+    "    api.update(path=PATH, sibling=SIBLING_NAME, how='merge')\n",
+    "except:\n",
+    "    DATALAD_ERROR = traceback.format_exc()\n",
+    "    DATALAD_MESSAGE = 'リポジトリ側の変更と競合しました。競合を解決してください。'\n",
+    "else:\n",
+    "    try:\n",
+    "        # リポジトリにJupyter環境の更新をプッシュする\n",
+    "        api.unlock(PATH)\n",
+    "        api.push(to=SIBLING_NAME, result_renderer=RESULT_RENDERER, path=PATH, recursive=IS_RECURSIVE)\n",
+    "    except:\n",
+    "        DATALAD_ERROR = traceback.format_exc()\n",
+    "        DATALAD_MESSAGE = 'リポジトリへの同期に失敗しました。'\n",
+    "    else:\n",
+    "        DATALAD_MESSAGE = 'データ同期が完了しました。次の処理にお進みください。'\n",
+    "finally:\n",
+    "    # 実行結果を格納する\n",
+    "    %store DATALAD_MESSAGE\n",
+    "    %store DATALAD_ERROR"
    ]
   }
  ],

--- a/FLOW/util/base_required_every_time.ipynb
+++ b/FLOW/util/base_required_every_time.ipynb
@@ -368,6 +368,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "57c40704",
+   "metadata": {},
+   "source": [
+    "以下を実行して、`リポジトリ側の変更と競合しました。競合を解決してください。`と表示された場合は、[こちらのFAQ](http://dg02.dg.rcos.nii.ac.jp/G-Node/Info/wiki/%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC#1-1%E5%90%8C%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E5%81%B4%E3%81%AE%E5%A4%89%E6%9B%B4%E3%81%A8%E7%AB%B6%E5%90%88%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E7%AB%B6%E5%90%88%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)を参考に競合を解決してください。"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "5abba0fe",
@@ -375,14 +383,22 @@
    "outputs": [],
    "source": [
     "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "%cd ~/WORKFLOWS/FLOW/util\n",
-    "pm.execute_notebook(\n",
-    "    './base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = '[GIN] 研究リポジトリ初期設定を完了', TO_GIT=True)\n",
-    ")\n",
-    "print('データ同期が完了しました。')\n"
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        './base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = '[GIN] 研究リポジトリ初期設定を完了', TO_GIT=True)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   },
   {

--- a/monitor_package.ipynb
+++ b/monitor_package.ipynb
@@ -402,23 +402,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "以下を実行して、`リポジトリ側の変更と競合しました。競合を解決してください。`と表示された場合は、[こちらのFAQ](http://dg02.dg.rcos.nii.ac.jp/G-Node/Info/wiki/%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC#1-1%E5%90%8C%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B%E3%81%A8%E3%80%81%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E5%81%B4%E3%81%AE%E5%A4%89%E6%9B%B4%E3%81%A8%E7%AB%B6%E5%90%88%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%E7%AB%B6%E5%90%88%E3%82%92%E8%A7%A3%E6%B1%BA%E3%81%97%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)を参考に競合を解決してください。"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import papermill as pm\n",
     "import os\n",
+    "import papermill as pm\n",
+    "from colorama import Fore\n",
+    "from IPython.display import clear_output\n",
     "\n",
     "# 実験記録を上書きしない為に、このノートブックと実験パッケージのREADMEのみを書き戻す\n",
     "os.chdir('/home/jovyan')\n",
     "README_path = '/home/jovyan/' + package_path + '/README.md'\n",
     "save_path = [README_path, '/home/jovyan/WORKFLOWS/monitor_package.ipynb']\n",
-    "pm.execute_notebook(\n",
-    "    'WORKFLOWS/FLOW/util/base_datalad_save_push.ipynb',\n",
-    "    '/home/jovyan/.local/push_log.ipynb',\n",
-    "    parameters = dict(SAVE_MESSAGE = 'モニタリング（再現性）', IS_RECURSIVE = False, TO_GIT = True, PATH = save_path)\n",
-    ")"
+    "\n",
+    "try:\n",
+    "    pm.execute_notebook(\n",
+    "        'WORKFLOWS/FLOW/util/base_datalad_save_push.ipynb',\n",
+    "        '/home/jovyan/.local/push_log.ipynb',\n",
+    "        parameters = dict(SAVE_MESSAGE = 'モニタリング（再現性）', IS_RECURSIVE = False, TO_GIT = True, PATH = save_path)\n",
+    "    )\n",
+    "finally:\n",
+    "    clear_output()\n",
+    "    %store -r DATALAD_MESSAGE\n",
+    "    %store -r DATALAD_ERROR\n",
+    "    print('\\n' + DATALAD_MESSAGE + '\\n')\n",
+    "    print(Fore.RED + DATALAD_ERROR)"
    ]
   },
   {


### PR DESCRIPTION
## やったこと

- リポジトリへの書き戻し処理にdatalad updateを追加した。
リポジトリ側に新しい更新があった場合は、マージしなければ書き戻せないため。
また、マージする前にJupyter環境の更新をコミットする必要があるため、datalad処理の流れをsave→update→unlock→pushとした。
- 競合が起こる可能性のあるすべてのセルにコンフリクト解決FAQへのリンクを追記した。

## やらないこと

なし。

## できるようになること（ユーザ目線）

リポジトリ側の更新を取り込める。
競合が起きた時の対応が分かる。

## できなくなること（ユーザ目線）

なし。

## 動作確認の内容と結果

[動作確認ノートブック](http://dg02.dg.rcos.nii.ac.jp/ivis-mizuguchi/DataladUpdate-test/src/master/WORKFLOWS/FLOW/util/base_required_every_time.ipynb)でコンフリクトが起きない場合と起きた場合の流れを確認した。
また、FAQの手順で競合が解消できることを確認した。

## その他


