### PR TITLE
Notebookのbinderhub対応

### DIFF
--- a/FLOW/01_preparation_phase/base_setup_data_analysis_tools.ipynb
+++ b/FLOW/01_preparation_phase/base_setup_data_analysis_tools.ipynb
@@ -6,7 +6,7 @@
     "tags": []
    },
    "source": [
-    "# 高性能実験環境を準備する\n",
+    "# 高性能実験環境を準備する(TBD)\n",
     "\n",
     "高性能実験環境として、[mdx](https://www.u-tokyo.ac.jp/focus/ja/press/z0310_00027.html)環境を利用するための設定をします。  \n",
     "以下のセルを上から順番に実行してください。  \n",
@@ -14,132 +14,15 @@
     "![UnfreezeBotton](https://raw.githubusercontent.com/NII-DG/workflow-template/develop/sections/images/unfreeze_button.png)\n",
     "\n",
     "◆◆◆開発メモ◆◆◆  \n",
-    "将来的には、[学認クラウドオンデマンド構築サービス](https://cloud.gakunin.jp/ocs/)による動的な環境構築を実現する。"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## 1. 高性能実験環境への接続情報の入力\n",
-    "\n",
-    "以下のセルを実行し、表示されるフォームに高性能実験環境への接続情報を入力してください。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import clear_output\n",
-    "import getpass\n",
-    "ip_mdx = input(\"利用する高性能実験環境のIPアドレス：\")\n",
-    "name_mdx = input(\"高性能実験環境におけるSSHユーザ名：\")\n",
-    "clear_output()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## 2. アカウント認証のための設定\n",
-    "\n",
-    "[こちら](../../../../tree) を押下し、ファイル一覧画面に遷移してください。  \n",
-    "遷移後、id_rsaファイルをドラッグアンドドロップによりアップロードしてください。  \n",
-    "アップロード後、以下のセルを実行してください。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!mkdir -p /home/jovyan/.ssh/\n",
-    "!mv ~/id_rsa* ~/.ssh/id_rsa\n",
-    "!chmod 600 ~/.ssh/id_rsa"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## 3. 高性能実験環境への接続設定の実施\n",
-    "\n",
-    "以下のセルを実行し、高性能実験環境に接続するための設定を実施してください。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "path_flow_root = '/home/jovyan/WORKFLOWS/FLOW/'\n",
-    "os.chdir(path_flow_root)\n",
-    "from util.scripts import utils\n",
-    "import json\n",
-    "\n",
-    "# 以下の認証の手順で用いる、\n",
-    "# GINのドメイン名等をパラメタファイルから取得する\n",
-    "params = {}\n",
-    "with open(utils.fetch_param_file_path(), mode='r') as f:\n",
-    "    params = json.load(f)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%cd ~/WORKFLOWS/EX-WORKFLOWS/util/scripts\n",
-    "import utils\n",
-    "from IPython.display import clear_output\n",
-    "\n",
-    "import json\n",
-    "import os\n",
-    "\n",
-    "# mdx接続情報を設定ファイルに記述する\n",
-    "utils.config_mdx(name_mdx=name_mdx, mdxDomain=ip_mdx)\n",
-    "clear_output()"
+    "将来的には、[学認クラウドオンデマンド構築サービス](https://cloud.gakunin.jp/ocs/)による動的な環境構築を実現する。\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. 接続テスト\n",
-    "\n",
-    "以下のセルを実行し、「高性能実験環境と正常に接続されています」と表示されることを確認してください。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ssh mdx \"echo 高性能実験環境と正常に接続されています\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 5. ワークフロー機能トップページに遷移する\n",
-    "\n",
-    "続けてワークフロー機能を実行する場合は、[こちら](../../base_FLOW.ipynb)からトップページに遷移できます。  "
+    "<span style=\"font-size: 200%; color: red;\">本セクションは現在、作業はありません。</span><br>\n",
+    "<span style=\"font-size: 200%; color: red;\">[こちら](../../base_FLOW.ipynb)からトップページに遷移できます。  </span>"
    ]
   }
  ],

--- a/FLOW/02_experimental_phase/base_launch_an_experiment.ipynb
+++ b/FLOW/02_experimental_phase/base_launch_an_experiment.ipynb
@@ -159,122 +159,54 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### - 3-B. 高性能実験環境での実験\n",
+    "### - 3-B. 高性能実験環境(GPUあり)環境での実験\n",
     "\n",
-    "以下のセルを実行し、「高性能実験環境と正常に接続されています」と表示されることを確認してください。  \n",
-    "表示されない場合、[高性能実験環境を準備する](../01_preparation_phase/base_setup_data_analysis_tools.ipynb) の手順を実施してください。"
+    "以下のセルを実行した後に出力されるリンクをクリックして実験に移ってください。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "!ssh mdx \"echo 高性能実験環境と正常に接続されています\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "高性能実験環境の接続先情報を取得します。以下のセルを実行してください。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
    "outputs": [],
    "source": [
-    "mdx_host = ''\n",
-    "with open('/home/jovyan/.ssh/config', 'r') as f:\n",
-    "    tmp = f.read()\n",
-    "    tmp = tmp[tmp.find('mdx'):]\n",
-    "    tmp = tmp[tmp.find('Hostname ') + len('Hostname '):]\n",
-    "    mdx_host = tmp[:tmp.find('\\n')]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "高性能実験環境に実験パッケージ情報を転送します。以下のセルを実行してください。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# コンテナを起動する毎に最新のリポジトリをクローンする\n",
-    "list = !ssh mdx ls\n",
-    "for path in list:\n",
-    "    if path == repository_title:\n",
-    "        !ssh mdx rm -rf $repository_title\n",
+    "import urllib\n",
     "\n",
-    "cmd = \"git clone \" + remote_http_url\n",
-    "!ssh mdx $cmd"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "高性能実験環境においてJupyterLabを起動します。以下のセルを実行してください。  \n",
-    "実行後、表示されるリンクをクリックすると、パスワードの入力が求められますので「gpu-jupyter」と入力してLoginしてください。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from IPython.display import clear_output\n",
-    "\n",
-    "# JupyterLabコンテナイメージの作成\n",
-    "cmd = \"docker build -t dg/jupyterlab:1.1 ./\" + repository_title + \"/\"\n",
-    "!ssh mdx $cmd\n",
-    "clear_output()\n",
-    "\n",
-    "# JupyterLabコンテナの起動\n",
-    "if mdx_host == '163.220.176.51':\n",
-    "    cmd = \"docker run --gpus all -d -P dg/jupyterlab:1.1\"\n",
-    "else:\n",
-    "    cmd = \"docker run -d -P dg/jupyterlab:1.1\"\n",
-    "container_id = !ssh mdx $cmd\n",
-    "container_id = container_id[0][:12]\n",
-    "\n",
-    "# ホストマシン上で動的に割り当てられたポートを取得\n",
-    "cmd = \"docker ps -l\"\n",
-    "port = !ssh mdx $cmd\n",
-    "port = port[1]\n",
-    "port = port[port.find(\"0.0.0.0:\") + 8: port.find(\"->8888/tcp\")]\n",
-    "\n",
-    "# JupyterLab利用のためのURLを表示\n",
     "if selected_workflow==1:\n",
-    "    url = \"http://\" + mdx_host + \":\" + str(port) + \"/notebooks/WORKFLOWS/experiment.ipynb\"\n",
+    "    print(\n",
+    "        \"http://163.220.176.51:10980/v2/git/\" + urllib.parse.quote(remote_http_url, safe='') + \"/HEAD?filepath=WORKFLOWS/experiment.ipynb\"\n",
+    "    )\n",
     "elif selected_workflow==2:\n",
-    "    url = \"http://\" + mdx_host + \":\" + str(port) + \"/notebooks/WORKFLOWS/monitor_package.ipynb\"\n",
-    "print(url)"
+    "    print(\n",
+    "        \"http://163.220.176.51:10980/v2/git/\" + urllib.parse.quote(remote_http_url, safe='') + \"/HEAD?filepath=WORKFLOWS/monitor_package.ipynb\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### - 3-C. 高性能実験環境(GPUなし)環境での実験\n",
+    "\n",
+    "以下のセルを実行した後に出力されるリンクをクリックして実験に移ってください。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib\n",
+    "\n",
+    "if selected_workflow==1:\n",
+    "    print(\n",
+    "        \"http://163.220.176.50:10980/v2/git/\" + urllib.parse.quote(remote_http_url, safe='') + \"/HEAD?filepath=WORKFLOWS/experiment.ipynb\"\n",
+    "    )\n",
+    "elif selected_workflow==2:\n",
+    "    print(\n",
+    "        \"http://163.220.176.50:10980/v2/git/\" + urllib.parse.quote(remote_http_url, safe='') + \"/HEAD?filepath=WORKFLOWS/monitor_package.ipynb\"\n",
+    "    )"
    ]
   },
   {


### PR DESCRIPTION
## やったこと

BinderHubの作成に伴った、構築用URLの作成処理の変更。
上記に伴った高性能環境構築用手順の削除。

## やらないこと

なし

## できるようになること（ユーザ目線）

mdx上でのBinderHubの利用

## できなくなること（ユーザ目線）

mdx上でのjypiterLabの利用
mdxへのssh接続

## 動作確認の内容と結果

該当のノートブックからコンテナが生成できることを確認。