### PR TITLE
Develop/sync except s3objects

### DIFF
--- a/EX-WORKFLOWS/util/required_every_time.ipynb
+++ b/EX-WORKFLOWS/util/required_every_time.ipynb
@@ -451,6 +451,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bed8319e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# S3にあるデータをGIN-forkに同期しないための設定\n",
+    "!git annex untrust here\n",
+    "!git annex --force trust web"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "1d804955",
    "metadata": {},

--- a/EX-WORKFLOWS/util/required_every_time.ipynb
+++ b/EX-WORKFLOWS/util/required_every_time.ipynb
@@ -451,18 +451,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bed8319e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# S3にあるデータをGIN-forkに同期しないための設定\n",
-    "!git annex untrust here\n",
-    "!git annex --force trust web"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "1d804955",
    "metadata": {},
@@ -530,7 +518,11 @@
     "from util.scripts import utils\n",
     "\n",
     "# SSHホスト（＝GIN）を信頼する設定\n",
-    "utils.config_GIN(ginHttp = params['siblings']['ginHttp'])"
+    "utils.config_GIN(ginHttp = params['siblings']['ginHttp'])\n",
+    "\n",
+    "# S3にあるデータをGIN-forkに同期しないための設定\n",
+    "!git annex untrust here\n",
+    "!git annex --force trust web"
    ]
   },
   {

--- a/FLOW/util/base_required_every_time.ipynb
+++ b/FLOW/util/base_required_every_time.ipynb
@@ -198,18 +198,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1a92c110",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# S3にあるデータをGIN-forkに同期しないための設定\n",
-    "!git annex untrust here\n",
-    "!git annex --force trust web"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "88c7b474",
    "metadata": {},
@@ -379,7 +367,11 @@
     "from util.scripts import utils\n",
     "\n",
     "# SSHホスト（＝GIN）を信頼する設定\n",
-    "utils.config_GIN(ginHttp = params['siblings']['ginHttp'])"
+    "utils.config_GIN(ginHttp = params['siblings']['ginHttp'])\n",
+    "\n",
+    "# S3にあるデータをGIN-forkに同期しないための設定\n",
+    "!git annex untrust here\n",
+    "!git annex --force trust web"
    ]
   },
   {

--- a/FLOW/util/base_required_every_time.ipynb
+++ b/FLOW/util/base_required_every_time.ipynb
@@ -198,6 +198,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a92c110",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# S3にあるデータをGIN-forkに同期しないための設定\n",
+    "!git annex untrust here\n",
+    "!git annex --force trust web"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "88c7b474",
    "metadata": {},
@@ -461,7 +473,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.5 64-bit",
+   "display_name": "Python 64-bit ('.')",
    "language": "python",
    "name": "python3"
   },
@@ -475,11 +487,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": ""
   },
   "vscode": {
    "interpreter": {
-    "hash": "6a196852dad78838558c3d25678ed4fa7922e766dc7a8a519a679191ca8fa666"
+    "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
    }
   }
  },

--- a/FLOW/util/scripts/utils.py
+++ b/FLOW/util/scripts/utils.py
@@ -222,6 +222,9 @@ def syncs_with_repo(git_path, gitannex_path, message):
     datalad_message = ''
     datalad_error = ''
     try:
+        # lock状態でないとS3データが同期されてしまう
+        os.chdir(os.environ['HOME'])
+        os.system('git annex lock')
         save(git_path, gitannex_path, message)
         update()
     except:

--- a/FLOW/util/scripts/utils.py
+++ b/FLOW/util/scripts/utils.py
@@ -266,7 +266,7 @@ def syncs_with_repo(git_path, gitannex_path, message):
                 os.system('git annex unlock')
             datalad_message = SUCCESS
     finally:
-        clear_output()
+        # clear_output() ※一時的に
         display(HTML("<p>" + datalad_message + "</p>"))
         display(HTML("<p><font color='red'>" + datalad_error + "</font></p>"))
 
@@ -280,5 +280,5 @@ def update():
     api.update(sibling=SIBLING, how='merge')
 
 def push():
-    api.push(to=SIBLING)
+    api.push(to=SIBLING, data='auto')
     

--- a/FLOW/util/scripts/utils.py
+++ b/FLOW/util/scripts/utils.py
@@ -269,7 +269,7 @@ def syncs_with_repo(git_path, gitannex_path, message):
                 os.system('git annex unlock')
             datalad_message = SUCCESS
     finally:
-        # clear_output() ※一時的に
+        clear_output()
         display(HTML("<p>" + datalad_message + "</p>"))
         display(HTML("<p><font color='red'>" + datalad_error + "</font></p>"))
 

--- a/monitor_package.ipynb
+++ b/monitor_package.ipynb
@@ -171,7 +171,11 @@
     "# SSHホスト（＝GIN）を信頼する設定\n",
     "# ドメイン名がハードコーディングにつき要修正\n",
     "with open('/home/jovyan/.ssh/config', mode='w') as f:\n",
-    "    f.write('host dg02.dg.rcos.nii.ac.jp\\n\\tStrictHostKeyChecking no\\n\\tUserKnownHostsFile=/dev/null\\n')"
+    "    f.write('host dg02.dg.rcos.nii.ac.jp\\n\\tStrictHostKeyChecking no\\n\\tUserKnownHostsFile=/dev/null\\n')\n",
+    "\n",
+    "# S3にあるデータをGIN-forkに同期しないための設定\n",
+    "!git annex untrust here\n",
+    "!git annex --force trust web"
    ]
   },
   {


### PR DESCRIPTION
## やったこと

git annexのリポジトリの信頼設定と、同期処理前のgit annex lock処理を追加することで、S3データはGIN-forkに同期しないように設定した。

## やらないこと

なし。

## できるようになること（ユーザ目線）

なし。

## できなくなること（ユーザ目線）

なし。

## 動作確認の内容と結果

S3からのデータや外部リポジトリを指すデータ（addurlで用意されたデータ）は同期されないことを確認した。
![image](https://user-images.githubusercontent.com/91708725/191703385-a8cb15ea-314d-42c6-b4e2-49c55f3b40cc.png)

## 水平展開（処理のモジュール化の検討を含む）の結果

水平展開を確認済み。

## その他

データのコピーがどこにあるかは、git annex listコマンドで確認できます。
git annexのリポジトリの信頼設定は、git annex infoコマンドで確認できます。
