### PR TITLE
モンキーテスト項番12の水平展開漏れ対応

### DIFF
--- a/monitor_package.ipynb
+++ b/monitor_package.ipynb
@@ -148,9 +148,9 @@
     "    params['ginKeyId'] = str(response.json()['id'])\n",
     "    with open(utils.fetch_param_file_path(), mode='w') as f:\n",
     "        json.dump(params, f, indent=4)\n",
-    "    print('Public key is ready.')\n",
+    "    print('公開鍵の用意が出来ました。')\n",
     "elif msg['message'] == 'Key content has been used as non-deploy key':\n",
-    "    print('Public key is ready before time.')"
+    "    print('すでに公開鍵の用意が完了しています。')"
    ]
   },
   {
@@ -179,7 +179,7 @@
     "        pass\n",
     "\n",
     "clear_output()\n",
-    "print('SSH connection is ready.')"
+    "print('SSH接続の準備が完了しました。')"
    ]
   },
   {
@@ -464,18 +464,18 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.5 64-bit",
+   "display_name": "Python 64-bit ('.')",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.9.5"
+   "version": ""
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "6a196852dad78838558c3d25678ed4fa7922e766dc7a8a519a679191ca8fa666"
+    "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
    }
   }
  },


### PR DESCRIPTION
## やったこと

モンキーテスト項番12の水平展開の漏れがあり、monitor_package.ipynbの出力セルが英語のままになっていたので修正した。

## やらないこと

なし。

## できるようになること（ユーザ目線）

なし。

## できなくなること（ユーザ目線）

なし。

## 動作確認の内容と結果

出力表示が日本語で行われることを確認した。

## 水平展開（処理のモジュール化の検討を含む）の結果

接続設定を行う3タスクで展開完了した。

## その他

なし。
