### PR TITLE
sdDatePublishedを日時ではなく日付で定義する修正

### DIFF
--- a/FLOW/util/scripts/utils.py
+++ b/FLOW/util/scripts/utils.py
@@ -385,10 +385,8 @@ def register_metadata_for_downloaded_annexdata(file_path):
     EXCEPTION
     ---------------
     """
-    t_delta = datetime.timedelta(hours=9)
-    JST = datetime.timezone(t_delta, 'JST')
-    current_time = datetime.datetime.now(JST)
-    sd_date_published = current_time.isoformat()
+    current_date = datetime.date.today()
+    sd_date_published = current_date.isoformat()
     os.system(f'git annex metadata {file_path} -s sd_date_published={sd_date_published}')
 
 # 研究名と実験名を表示する関数


### PR DESCRIPTION
## やったこと

S3などからダウンロードしたファイルに付与するsdDatePublishedメタデータをISO形式の日時で定義していましたが、検証ルールに合わせてISO形式の日付で定義するように更新しました。
以下のプルリクエストの修正です。
https://github.com/NII-DG/workflow-template/pull/65

## やらないこと

なし。

## できるようになること（ユーザ目線）

なし。

## できなくなること（ユーザ目線）

なし。

## 動作確認の内容と結果

修正後は、検証ルールで例外が発生しないことを確認しました。

## 水平展開（処理のモジュール化の検討を含む）の結果

なし。

## その他

なし。
