### PR TITLE
Bug in creation of gin-fork ssh URL when executing research workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .datalad/
 .gitattributes
 .ipynb_checkpoints/
+
+env*

--- a/FLOW/util/base_required_every_time.ipynb
+++ b/FLOW/util/base_required_every_time.ipynb
@@ -242,6 +242,8 @@
     ".gitconfig\n",
     ".repository_id\n",
     ".token.json\n",
+    ".github\n",
+    "__pycache__/\n",
     "\" >> ~/.gitignore\n",
     "\n",
     "fi"

--- a/utils/param_json/param_json.py
+++ b/utils/param_json/param_json.py
@@ -35,16 +35,29 @@ def update_param_url(remote_origin_url):
         response = api.repos(pr.scheme, pr.netloc, owner_repo_nm)
         if response.status_code == HTTPStatus.OK:
             flg = False
-            response_data = response.json()
-            pr_http = parse.urlparse(response_data["html_url"])
-            pr_ssh = parse.urlparse(response_data["ssh_url"])
+
 
             f = open(param_file_path, 'r')
             df = json.load(f)
             f.close()
 
+            response_data = response.json()
+
+            # Create http url for gin-fork
+            pr_http = parse.urlparse(response_data["html_url"])
             df["siblings"]["ginHttp"] = parse.urlunparse((pr_http.scheme, pr_http.netloc, "", "", "", ""))
-            df["siblings"]["ginSsh"] = parse.urlunparse((pr_ssh.scheme, pr_ssh.netloc, "", "", "", ""))
+
+            # Create ssf url for gin-fork
+            # git@it1.dg.nii.ac.jp:/ivis-tsukioka/r1.git -> git@it1.dg.nii.ac.jp:
+            # ssh://git@dg01.dg.rcos.nii.ac.jp:3001/ivis-tsukioka/repo1.git -> ssh://git@dg01.dg.rcos.nii.ac.jp:3001
+            ssh_url = response_data["ssh_url"]
+            repo_slash_index = ssh_url.rfind("/")
+            ssh_url = ssh_url[:repo_slash_index-1]
+            user_slash_index = ssh_url.rfind("/")
+            ssh_url = ssh_url[:user_slash_index-1]
+            print(ssh_url)
+
+            df["siblings"]["ginSsh"] = ssh_url
 
             with open(param_file_path, 'w') as f:
                 json.dump(df, f, indent=4)

--- a/utils/param_json/param_json.py
+++ b/utils/param_json/param_json.py
@@ -49,14 +49,10 @@ def update_param_url(remote_origin_url):
 
             # Create ssf url for gin-fork
             ssh_url = response_data["ssh_url"]
-            print(ssh_url)
             repo_slash_index = ssh_url.rfind("/")
             ssh_url = ssh_url[:repo_slash_index]
-            print(ssh_url)
             user_slash_index = ssh_url.rfind("/")
             ssh_url = ssh_url[:user_slash_index]
-            print(ssh_url)
-
             df["siblings"]["ginSsh"] = ssh_url
 
             with open(param_file_path, 'w') as f:

--- a/utils/param_json/param_json.py
+++ b/utils/param_json/param_json.py
@@ -49,10 +49,13 @@ def update_param_url(remote_origin_url):
 
             # Create ssf url for gin-fork
             ssh_url = response_data["ssh_url"]
+            print(ssh_url)
             repo_slash_index = ssh_url.rfind("/")
             ssh_url = ssh_url[:repo_slash_index-1]
+            print(ssh_url)
             user_slash_index = ssh_url.rfind("/")
             ssh_url = ssh_url[:user_slash_index-1]
+            print(ssh_url)
 
             df["siblings"]["ginSsh"] = ssh_url
 

--- a/utils/param_json/param_json.py
+++ b/utils/param_json/param_json.py
@@ -51,10 +51,10 @@ def update_param_url(remote_origin_url):
             ssh_url = response_data["ssh_url"]
             print(ssh_url)
             repo_slash_index = ssh_url.rfind("/")
-            ssh_url = ssh_url[:repo_slash_index-1]
+            ssh_url = ssh_url[:repo_slash_index]
             print(ssh_url)
             user_slash_index = ssh_url.rfind("/")
-            ssh_url = ssh_url[:user_slash_index-1]
+            ssh_url = ssh_url[:user_slash_index]
             print(ssh_url)
 
             df["siblings"]["ginSsh"] = ssh_url

--- a/utils/param_json/param_json.py
+++ b/utils/param_json/param_json.py
@@ -48,14 +48,11 @@ def update_param_url(remote_origin_url):
             df["siblings"]["ginHttp"] = parse.urlunparse((pr_http.scheme, pr_http.netloc, "", "", "", ""))
 
             # Create ssf url for gin-fork
-            # git@it1.dg.nii.ac.jp:/ivis-tsukioka/r1.git -> git@it1.dg.nii.ac.jp:
-            # ssh://git@dg01.dg.rcos.nii.ac.jp:3001/ivis-tsukioka/repo1.git -> ssh://git@dg01.dg.rcos.nii.ac.jp:3001
             ssh_url = response_data["ssh_url"]
             repo_slash_index = ssh_url.rfind("/")
             ssh_url = ssh_url[:repo_slash_index-1]
             user_slash_index = ssh_url.rfind("/")
             ssh_url = ssh_url[:user_slash_index-1]
-            print(ssh_url)
 
             df["siblings"]["ginSsh"] = ssh_url
 


### PR DESCRIPTION
# PULL REQUEST

## Background

* Bug in creation of gin-fork ssh URL when executing research workflow
* Bug with git management of files not needed in the research repository.
![image](https://user-images.githubusercontent.com/96706614/227681816-69f26487-e24a-4aac-af0f-89f039d488b8.png)
![image](https://user-images.githubusercontent.com/96706614/227681839-f8c1a4b3-4904-4e83-84ce-e899ef13c611.png)

## Main Points of Modification

* Fixed ssh URL creation process.
* Excluded .github and __pycahe__ folders from git management.

## Test

* The expected sshURL was created.
*  Synchronized with gin-fork with the created sshURL.

![image](https://user-images.githubusercontent.com/96706614/227680319-243c6912-310a-4bf9-b69e-81895568589f.png)
![image](https://user-images.githubusercontent.com/96706614/227680483-985c2a0a-692e-46c5-93b0-a19faa3deae1.png)

## Viewpoint for Review

*

## Supplementary Information


*
## ToDo

*
