### PR TITLE
Export environment configuration information

### DIFF
--- a/EX-WORKFLOWS/finish.ipynb
+++ b/EX-WORKFLOWS/finish.ipynb
@@ -48,15 +48,8 @@
    "outputs": [],
    "source": [
     "%store -r EXPERIMENT_TITLE\n",
-    "\n",
-    "# *Identify the CONDA environment in the ACTIVATE state.\n",
-    "env_list = !conda env list\n",
-    "for env in env_list:\n",
-    "    if '*' in env:\n",
-    "        env = env.split(' ')\n",
-    "        activate_env = env[0]\n",
-    "\n",
-    "!conda env export -n $activate_env > ~/experiments/$EXPERIMENT_TITLE/environment.yml\n",
+    "# Export environment configuration information(conda base env)\n",
+    "!conda env export -n base > ~/experiments/$EXPERIMENT_TITLE/environment.yml\n",
     "!pip freeze > ~/experiments/$EXPERIMENT_TITLE/requirements.txt"
    ]
   },


### PR DESCRIPTION
# PULL REQUEST

## Background

* In GIN-fork, environment building files are now limited to DocerFile.
* The above change limits the export of environmental configuration information to "base".


## Main Points of Modification

* When exporting environment configuration information, the environment name "base" is now specified for exporting.

## Test

* We confirmed that the code appendage function and the mdx environment successfully write out the environment configuration information.

* code attachment function
![image](https://user-images.githubusercontent.com/96706614/232478422-56235b71-6214-4a7e-a0cf-89cc3db7f820.png)

* mdx
![image](https://user-images.githubusercontent.com/96706614/232478378-4242e08a-8205-42ca-80cb-7f426c169301.png)

## Viewpoint for Review

*

## Supplementary Information
* https://github.com/NII-DG/maDMP-template/pull/43
* https://github.com/NII-DG/dg-manual/pull/17
## ToDo

*
