### PR TITLE
git annex lock before pulling

### DIFF
--- a/FLOW/util/scripts/utils.py
+++ b/FLOW/util/scripts/utils.py
@@ -308,9 +308,11 @@ def save_and_register_metadata(git_path, gitannex_path, gitannex_files, message)
         # register metadata for gitannex_files
         if type(gitannex_files) == str:
             register_metadata_for_annexdata(gitannex_files)
+            os.system('git annex lock')
         elif type(gitannex_files) == list:
             for file in gitannex_files:
                 register_metadata_for_annexdata(file)
+            os.system('git annex lock')
         else:
             # if gitannex_files is not defined as a single file path (str) or multiple file paths (list), no metadata is given.
             pass
@@ -323,6 +325,7 @@ def update():
 
 def push():
     api.push(to=SIBLING, data='auto')
+    os.system('git annex unlock')
   
 def register_metadata_for_annexdata(file_path):
     """register_metadata(content_size, sha256, mime_type) for specified file


### PR DESCRIPTION
# PULL REQUEST

## Background

* datalad When unlocked, it is recognized that there is an update in the file and update/push cannot be performed.

## Main Points of Modification

* datalad Push with lock state, and unlock after push.

## Test

*Conducted in an IT1 environment.

## Viewpoint for Review

* Nothing.

## Supplementary Information

* Nothing.

## ToDo

* Nothing.
