### PR TITLE
Feature/fix gitkeep and pipeline

### DIFF
--- a/EX-WORKFLOWS/finish.ipynb
+++ b/EX-WORKFLOWS/finish.ipynb
@@ -149,8 +149,7 @@
     "files.extend(dirs)\n",
     "save_path = []\n",
     "for file in files:\n",
-    "    save_path.append(experiment_path + '/' + file)\n",
-    "save_path.append('/home/jovyan/pipeline.json')"
+    "    save_path.append(experiment_path + '/' + file)"
    ]
   },
   {

--- a/EX-WORKFLOWS/prepare_parameter_experiment.ipynb
+++ b/EX-WORKFLOWS/prepare_parameter_experiment.ipynb
@@ -274,8 +274,7 @@
     "files.extend(dirs)\n",
     "save_path = []\n",
     "for file in files:\n",
-    "    save_path.append(experiment_path + '/' + file)\n",
-    "save_path.append('/home/jovyan/pipeline.json')"
+    "    save_path.append(experiment_path + '/' + file)"
    ]
   },
   {

--- a/EX-WORKFLOWS/util/required_every_time.ipynb
+++ b/EX-WORKFLOWS/util/required_every_time.ipynb
@@ -256,7 +256,8 @@
     "os.chdir(experiment_path)\n",
     "\n",
     "new_dir_path_recursive = 'source/test'\n",
-    "os.makedirs(new_dir_path_recursive, exist_ok=True)\n"
+    "os.makedirs(new_dir_path_recursive, exist_ok=True)\n",
+    "!touch $new_dir_path_recursive/.gitkeep"
    ]
   },
   {
@@ -282,7 +283,8 @@
     "os.chdir(experiment_path)\n",
     "\n",
     "new_dir_path_recursive = 'ci'\n",
-    "os.makedirs(new_dir_path_recursive, exist_ok=True)"
+    "os.makedirs(new_dir_path_recursive, exist_ok=True)\n",
+    "!touch $new_dir_path_recursive/.gitkeep"
    ]
   },
   {


### PR DESCRIPTION
# PULL REQUEST

## Background

* Since there is no .gitkeep, the ci and test folders are not synchronized in required_every_time.ipynb.
* In the prepare_parameter_experiment.ipynb and finish.ipynb, pipeline.json is synchronized, but it is not needed.

## Main Points of Modification

* In  required_every_time.ipynb, store .gitkeep in two folders.
* In the prepare_parameter_experiment.ipynb and finish.ipynb, do not include pipeline.json in the sync target.

## Test

* required_every_time.ipynb synchronize ci, test folders.
![image](https://user-images.githubusercontent.com/91708725/234573215-d9ff5707-869c-4eeb-a3cf-c54756ce0ebb.png)

* After running up to finish.ipynb in the experiment package, the history of pipeline.json shows that it has not been updated since the required_every_time.ipynb.
![image](https://user-images.githubusercontent.com/91708725/234573621-9d6018e7-5e6c-43bc-a95b-078f40d254f3.png)

## Viewpoint for Review

* Nothing.

## Supplementary Information

* Nothing.

## ToDo

* Nothing.
