### PR TITLE
Discontinue use of pipeline.json

### DIFF
--- a/EX-WORKFLOWS/prepare_from_repository.ipynb
+++ b/EX-WORKFLOWS/prepare_from_repository.ipynb
@@ -18,6 +18,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -41,6 +42,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -109,6 +111,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -129,72 +132,86 @@
     "import glob \n",
     "from ipywidgets import Dropdown, Button, Layout\n",
     "from IPython.display import clear_output\n",
+    "import os\n",
     "\n",
     "\n",
     "# Retrieve a set of experimental packages in the input repository.\n",
     "input_repo_path = '/home/jovyan/.tmp/' + input_repo.split('/')[-1].replace('.git', '')\n",
-    "with open(input_repo_path + '/pipeline.json', 'r') as f:\n",
-    "    pipeline = json.load(f)\n",
+    "input_repo_experiments_path = '{}/{}'.format(input_repo_path, 'experiments')\n",
+    "print('[Debug log] input_repo_experiments_path : {}'.format(input_repo_experiments_path))\n",
     "\n",
-    "# Accepts input of experimental packages for which data are to be obtained via GUI.\n",
-    "style = {'description_width': 'initial'}\n",
-    "print('取得したいデータを持つ実験パッケージ名を以下から選択し、入力完了ボタンをクリック下さい。')\n",
-    "    \n",
-    "def on_click_package(clicked_button: Button) -> None:\n",
-    "    def on_click_parameter(clicked_button: Button) -> None:\n",
-    "        global parameter\n",
-    "        print(\"HERE\")\n",
-    "        parameter=dropdown_parameter.value\n",
+    "ex_pkg_list = list[str]()\n",
+    "if os.path.isdir(input_repo_experiments_path):\n",
+    "    for data_name in os.listdir(input_repo_experiments_path):\n",
+    "        data_path = os.path.join(input_repo_experiments_path,data_name)\n",
+    "        if os.path.isdir(data_path):\n",
+    "            print('[Debug log] data_name add to ex_pkg_list: {}'.format(data_name))\n",
+    "            ex_pkg_list.append(data_name)\n",
+    "\n",
+    "print('[Debug log] ex_pkg_list : {}'.format(ex_pkg_list))\n",
+    "if len(ex_pkg_list) > 0:\n",
+    "    # Accepts input of experimental packages for which data are to be obtained via GUI.\n",
+    "    style = {'description_width': 'initial'}\n",
+    "    print('取得したいデータを持つ実験パッケージ名を以下から選択し、入力完了ボタンをクリック下さい。')\n",
+    "        \n",
+    "    def on_click_package(clicked_button: Button) -> None:\n",
+    "        def on_click_parameter(clicked_button: Button) -> None:\n",
+    "            global parameter\n",
+    "            print(\"HERE\")\n",
+    "            parameter=dropdown_parameter.value\n",
+    "            clear_output()\n",
+    "            print('入力を受けつけました。')\n",
+    "            print('実験パッケージ名：', package)\n",
+    "            print('パラメータ実験名：', parameter)\n",
+    "        \n",
+    "        global package\n",
+    "        package=dropdown_package.value\n",
     "        clear_output()\n",
     "        print('入力を受けつけました。')\n",
     "        print('実験パッケージ名：', package)\n",
-    "        print('パラメータ実験名：', parameter)\n",
-    "    \n",
-    "    global package\n",
-    "    package=dropdown_package.value\n",
-    "    clear_output()\n",
-    "    print('入力を受けつけました。')\n",
-    "    print('実験パッケージ名：', package)\n",
-    "    \n",
-    "    # In the for_parameters configuration, it also accepts input for the parameter folder.\n",
-    "    with open(input_repo_path + '/dmp.json', 'r') as f:\n",
-    "        global dmp\n",
-    "        dmp = json.load(f)\n",
-    "    if dmp['datasetStructure'] == 'for_parameters':\n",
-    "        # Generate parameter folder list.\n",
-    "        output_dirs = glob.glob(input_repo_path + '/experiments/' + package + '/**/output_data/', recursive=True)\n",
-    "        parameter_dirs = [dir.replace('/output_data/', '') for dir in output_dirs]\n",
-    "        parameter_dirs = [dir.replace(input_repo_path + '/experiments/' + package + '/', '') for dir in parameter_dirs]\n",
-    "        clear_output()\n",
-    "        print('取得したい出力データを持つパラメータ実験名を選択し、入力完了ボタンをクリック下さい。')\n",
     "        \n",
-    "        dropdown_parameter = Dropdown(\n",
-    "            options=parameter_dirs,\n",
-    "            description='パラメータ実験名:',\n",
-    "            disabled=False,\n",
-    "            layout=Layout(width='initial'),\n",
-    "            style=style\n",
-    "        )\n",
-    "        button_parameter = Button(description='入力完了する')\n",
-    "        button_parameter.on_click(on_click_parameter)\n",
-    "        display(dropdown_parameter, button_parameter)\n",
-    "    else:\n",
-    "        pass\n",
+    "        # In the for_parameters configuration, it also accepts input for the parameter folder.\n",
+    "        with open(input_repo_path + '/dmp.json', 'r') as f:\n",
+    "            global dmp\n",
+    "            dmp = json.load(f)\n",
+    "        if dmp['datasetStructure'] == 'for_parameters':\n",
+    "            # Generate parameter folder list.\n",
+    "            output_dirs = glob.glob(input_repo_path + '/experiments/' + package + '/**/output_data/', recursive=True)\n",
+    "            parameter_dirs = [dir.replace('/output_data/', '') for dir in output_dirs]\n",
+    "            parameter_dirs = [dir.replace(input_repo_path + '/experiments/' + package + '/', '') for dir in parameter_dirs]\n",
+    "            clear_output()\n",
+    "            print('取得したい出力データを持つパラメータ実験名を選択し、入力完了ボタンをクリック下さい。')\n",
+    "            \n",
+    "            dropdown_parameter = Dropdown(\n",
+    "                options=parameter_dirs,\n",
+    "                description='パラメータ実験名:',\n",
+    "                disabled=False,\n",
+    "                layout=Layout(width='initial'),\n",
+    "                style=style\n",
+    "            )\n",
+    "            button_parameter = Button(description='入力完了する')\n",
+    "            button_parameter.on_click(on_click_parameter)\n",
+    "            display(dropdown_parameter, button_parameter)\n",
+    "        else:\n",
+    "            pass\n",
     "\n",
-    "dropdown_package = Dropdown(\n",
-    "    options=pipeline,\n",
-    "    description='実験パッケージ名:',\n",
-    "    disabled=False,\n",
-    "    layout=Layout(width='initial'),\n",
-    "    style=style\n",
-    ")\n",
+    "    dropdown_package = Dropdown(\n",
+    "        options=ex_pkg_list,\n",
+    "        description='実験パッケージ名:',\n",
+    "        disabled=False,\n",
+    "        layout=Layout(width='initial'),\n",
+    "        style=style\n",
+    "    )\n",
     "\n",
-    "button_package = Button(description='入力完了')\n",
-    "button_package.on_click(on_click_package)\n",
-    "display(dropdown_package, button_package)"
+    "    button_package = Button(description='入力完了')\n",
+    "    button_package.on_click(on_click_package)\n",
+    "    display(dropdown_package, button_package)\n",
+    "else:\n",
+    "    print('選択されたリポジトリでは取得可能な実験パッケージは存在しません。選択されたリポジトリが正しいかご確認ください。')\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -284,6 +301,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -330,6 +348,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -398,6 +417,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -455,6 +475,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -475,6 +496,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -499,6 +521,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -522,6 +545,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/EX-WORKFLOWS/util/required_every_time.ipynb
+++ b/EX-WORKFLOWS/util/required_every_time.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4719bc46",
    "metadata": {},
@@ -14,6 +15,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "56a9110e",
    "metadata": {},
@@ -37,6 +39,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "134fa434",
    "metadata": {},
@@ -85,6 +88,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e4cde40b",
    "metadata": {},
@@ -143,25 +147,7 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5a295068",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# pipeline.jsonに実験名を追記する\n",
-    "import json\n",
-    "\n",
-    "with open('/home/jovyan/pipeline.json', 'r') as f:\n",
-    "    pipeline = json.load(f)\n",
-    "\n",
-    "pipeline.append(experiment_title)\n",
-    "\n",
-    "with open('/home/jovyan/pipeline.json', 'w') as f:\n",
-    "    json.dump(pipeline, f, indent = 4)\n"
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "543fa345",
    "metadata": {},
@@ -225,6 +211,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f9a2a59c",
    "metadata": {},
@@ -234,6 +221,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5deb8a3b",
    "metadata": {},
@@ -261,6 +249,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b0cab5ce",
    "metadata": {},
@@ -288,6 +277,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e4d73fb8",
    "metadata": {},
@@ -330,6 +320,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "20dc08c8",
    "metadata": {},
@@ -426,6 +417,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1d804955",
    "metadata": {},
@@ -463,6 +455,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "182e5262",
    "metadata": {},
@@ -574,11 +567,11 @@
     "files.extend(dirs)\n",
     "save_path = []\n",
     "for file in files:\n",
-    "    save_path.append(experiment_path + '/' + file)\n",
-    "save_path.append('/home/jovyan/pipeline.json')\n"
+    "    save_path.append(experiment_path + '/' + file)\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e68c5d91",
    "metadata": {},
@@ -602,6 +595,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "95b2ba2d",
    "metadata": {},
@@ -656,6 +650,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "984670bb",
    "metadata": {},

--- a/EX-WORKFLOWS/util/required_rebuild_container.ipynb
+++ b/EX-WORKFLOWS/util/required_rebuild_container.ipynb
@@ -27,11 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -54,11 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -100,11 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -123,11 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# 公開鍵アップロード\n",
@@ -165,11 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -197,11 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -230,37 +206,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
     "from ipywidgets import Dropdown, Button, Layout\n",
     "from IPython.display import clear_output\n",
     "\n",
-    "with open('/home/jovyan/pipeline.json', 'r') as f:\n",
-    "    pipeline = json.load(f)\n",
+    "input_repo_experiments_path = '/home/jovyan/experiments'\n",
     "\n",
-    "def on_click_callback(clicked_button: Button) -> None:\n",
-    "    global experiment_title\n",
-    "    experiment_title=dropdown.value\n",
-    "    clear_output()\n",
-    "    print(\"入力を受けつけました：\", experiment_title)\n",
+    "ex_pkg_list = list[str]()\n",
+    "if os.path.isdir(input_repo_experiments_path):\n",
+    "    for data_name in os.listdir(input_repo_experiments_path):\n",
+    "        data_path = os.path.join(input_repo_experiments_path,data_name)\n",
+    "        if os.path.isdir(data_path):\n",
+    "            ex_pkg_list.append(data_name)\n",
     "\n",
-    "dropdown = Dropdown(\n",
-    "    options=pipeline,\n",
-    "    description='実験パッケージ名:',\n",
-    "    disabled=False,\n",
-    "    style= {'description_width': 'initial'}\n",
-    ")\n",
+    "if len(ex_pkg_list) > 0:\n",
+    "    def on_click_callback(clicked_button: Button) -> None:\n",
+    "        global experiment_title\n",
+    "        experiment_title=dropdown.value\n",
+    "        clear_output()\n",
+    "        print(\"入力を受けつけました：\", experiment_title)\n",
     "\n",
-    "button = Button(description='入力完了')\n",
-    "button.on_click(on_click_callback)\n",
-    "print(\"実験パッケージの選択後、入力完了ボタンを押下してください。\")\n",
-    "display(dropdown, button)"
+    "    dropdown = Dropdown(\n",
+    "        options=ex_pkg_list,\n",
+    "        description='実験パッケージ名:',\n",
+    "        disabled=False,\n",
+    "        style= {'description_width': 'initial'}\n",
+    "    )\n",
+    "\n",
+    "    button = Button(description='入力完了')\n",
+    "    button.on_click(on_click_callback)\n",
+    "    print(\"実験パッケージの選択後、入力完了ボタンを押下してください。\")\n",
+    "    display(dropdown, button)\n",
+    "else:\n",
+    "    print('このリポジトリでは実験パッケージが存在しません。')"
    ]
   },
   {
@@ -276,11 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -313,11 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from IPython.display import display, Javascript\n",
@@ -335,11 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -364,11 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -418,11 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from IPython.display import display, HTML, Javascript\n",

--- a/FLOW/util/base_required_every_time.ipynb
+++ b/FLOW/util/base_required_every_time.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4b6b7c2a",
    "metadata": {},
@@ -14,6 +15,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "94a7313e",
    "metadata": {},
@@ -36,6 +38,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "396fd7ef",
    "metadata": {},
@@ -88,6 +91,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "47ab2ef7",
    "metadata": {},
@@ -189,6 +193,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "88c7b474",
    "metadata": {},
@@ -197,6 +202,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e18d033c-54af-4e79-be20-d6feaf0b7d8e",
    "metadata": {},
@@ -244,34 +250,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "781cf0ad-13ff-4bf3-938d-69ad7030fa18",
-   "metadata": {},
-   "source": [
-    "###  3-2. 実験パッケージ管理ファイルを作成する"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "75fec939-2f46-45cf-b0c7-d4c00c36f2e3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%sh\n",
-    "#!/bin/bash\n",
-    "if [ ! -f ~/pipeline.json ]; then\n",
-    "    # pipeline.jsonがなければ初期化\n",
-    "    echo \"[]\" > ~/pipeline.json\n",
-    "fi"
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "86cc20a7-cc8c-4e80-b892-47de45f07e76",
    "metadata": {},
    "source": [
-    "### 3-3. 実験パッケージに必要なファイルを追加する"
+    "### 3-2. 実験パッケージに必要なファイルを追加する"
    ]
   },
   {
@@ -292,11 +276,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3b0d26fe-3a6a-4e5e-9975-af37ec2125f5",
    "metadata": {},
    "source": [
-    "### 3-4. READMEに実行環境へのリンクを追加する"
+    "### 3-3. READMEに実行環境へのリンクを追加する"
    ]
   },
   {
@@ -333,6 +318,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "771fbbaf",
    "metadata": {
@@ -377,6 +363,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "57c40704",
    "metadata": {},
@@ -396,12 +383,13 @@
     "from util.scripts import utils\n",
     "os.chdir(os.environ['HOME'])\n",
     "\n",
-    "git_path = ['/home/jovyan/.gitignore', '/home/jovyan/WORKFLOWS', '/home/jovyan/pipeline.json', '/home/jovyan/README.md', '/home/jovyan/maDMP.ipynb']\n",
+    "git_path = ['/home/jovyan/.gitignore', '/home/jovyan/WORKFLOWS', '/home/jovyan/README.md', '/home/jovyan/maDMP.ipynb']\n",
     "\n",
     "is_ok = utils.syncs_with_repo(git_path, gitannex_path=None, gitannex_files=None, message='[GIN] 研究リポジトリ初期設定を完了')"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ab25d6d7",
    "metadata": {},
@@ -452,6 +440,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "845ce791",
    "metadata": {},


### PR DESCRIPTION
# PULL REQUEST

## Background
* In the RF, pipeline.json is used to record the experimental package names in that repository.
* The RF also retrieves the names of experimental packages from pipeline.json in order to allow users to specify the target experimental package when retrieving data from other repositories or setting up a rebuild.
* There is a problem in RF where pipeline.json is prone to git conflicts when syncing with GIN-fork.
* The use of the pipeline.json file was eliminated and the experimental package names were obtained from the directory structure.

## Main Points of Modification
* Eliminated the process of creating, writing, and reading the pipeline.json file.
* If necessary, the experimental package name was obtained from the directory structure.
* Changes in each Notebook
    * \FLOW\util\base_required_every_time.ipynb
       * Eliminated creation of empty pipeline.json
    *  \EX-WORKFLOWS\prepare_from_repository.ipynb
        *  Obtain the name of the experimental package from the folder structure
    * \EX-WORKFLOWS\util\required_every_time.ipynb
        *  Eliminate writing and synchronizing experimental package names to pipeline.json　
    * \EX-WORKFLOWS\util\required_rebuild_container.ipynb
        *  Fixed acquisition of experimental package names at rebuild time to be taken from the directory structure　

## Test

* We ran the Notebook with the changes to see if the results were as expected.
    *  \FLOW\util\base_required_every_time.ipynb
        *  Running the study container setup confirmed that an empty pipeline.json was not created.
![image](https://github.com/NII-DG/workflow-template/assets/96706614/bc231db7-45d3-4936-a529-a6dbff708cba)
![image](https://github.com/NII-DG/workflow-template/assets/96706614/93678667-0441-4492-abfc-56d7ef9efc59)
    *  \EX-WORKFLOWS\util\required_every_time.ipynb
        *  Setup and run the experimental container and make sure that pipeline.json is not written.
![image](https://github.com/NII-DG/workflow-template/assets/96706614/9c9f0003-a458-45ad-b169-66e4fa4949eb)
![image](https://github.com/NII-DG/workflow-template/assets/96706614/5d65de2d-b5ea-4b56-bbfd-93c27f8a9a48)

    *  \EX-WORKFLOWS\prepare_from_repository.ipynb
        * Must be able to run other repository data retrieval tasks in the experimental container to retrieve package names and data
![image](https://github.com/NII-DG/workflow-template/assets/96706614/503d47c7-8a02-4065-a33e-a3da016366cb)

    *  \EX-WORKFLOWS\util\required_rebuild_container.ipynb
        *  Experimental package must be available when rebuilding the experimental container.
![image](https://github.com/NII-DG/workflow-template/assets/96706614/4f16f1c3-85ea-4529-94fc-f8c33b8cd084)

## Viewpoint for Review

*

## Supplementary Information


*
## ToDo

*
