### PR TITLE
usability_remark_112

### DIFF
--- a/EX-WORKFLOWS/prepare_parameter_experiment.ipynb
+++ b/EX-WORKFLOWS/prepare_parameter_experiment.ipynb
@@ -129,7 +129,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. パラメータ実験用のディレクトリを追加する"
+    "## 2. パラメータ実験用のディレクトリを追加する\n",
+    "\n",
+    "当実験パッケージにパラメータ実験用のディレクトリを1セット追加します。  \n",
+    "パラメータ実験用のディレクトリの構成は以下です。\n",
+    "\n",
+    "パラメータ実験名/ ：パラメータ毎にパラメータ設定ファイルと出力データを配置するためのフォルダです。  \n",
+    "　┣ params/：パラメータ設定ファイルを配置するためのフォルダです。  \n",
+    "　┗ output_data/：パラメータ実験の出力データを配置するためのフォルダです。  \n",
+    "※パラメータ実験名フォルダは、手順2-2で入力いただくパラメータ実験名で用意します。"
    ]
   },
   {
@@ -137,41 +145,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2-1. パラメータ実験用のディレクトリを用意する"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# このコンテナで扱う実験パッケージのパスを作成する\n",
-    "%store -r EXPERIMENT_TITLE\n",
-    "experiment_path = '/home/jovyan/experiments/' + EXPERIMENT_TITLE\n",
-    "try:\n",
-    "    if is_activation:\n",
-    "        # /home/jovyan 配下に移動する\n",
-    "        os.chdir(os.environ['HOME'])\n",
-    "\n",
-    "        # ディレクトリを追加する\n",
-    "        !cp -r ~/WORKFLOWS/PACKAGE/scheme/$scheme_name/parameter $experiment_path\n",
-    "        print(\"次にお進みください。\")\n",
-    "    else:\n",
-    "        print(\"本タスクの対象外です。以下のリンクから実験フロートップページに戻ってください。\")\n",
-    "        display(HTML(\"<a href='../experiment.ipynb'>実験フロートップページに遷移する</a>\"))\n",
-    "except NameError as e :\n",
-    "    print(\"『1. 『パラメータ実験用ディレクトリの追加』のためのセクションを有効化する』セクションが実行されていません。\")\n"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2-2. パラメータ実験名を決定する\n",
+    "### 2-1. パラメータ実験名を決定する\n",
     "\n",
     "パラメータ実験名を入力して、実験データ格納用のディレクトリを作成します。\n",
     "\n",
@@ -180,8 +154,8 @@
     "また、「parameter」というパラメータ実験名も使用することができません。パラメータ名など分かりやすい名前をご記入ください。<br>\n",
     "\n",
     "**入力値に誤りがある場合は、以下を参照して対応してください。**\n",
-    "- 手順2-3以降が未実行である場合は、当セルを再度実行して訂正してください。  \n",
-    "- 手順2-3が実行済みである場合は、当セルを再度実行しても訂正ができません。以降の全てのセルを最後まで実行した後に、当タスクを最初のセルから再度実行して必要なパラメータ実験を用意してください。\n"
+    "- 手順2-2以降が未実行である場合は、当セルを再度実行して訂正してください。  \n",
+    "- 手順2-2が実行済みである場合は、当セルを再度実行しても訂正ができません。以降の全てのセルを最後まで実行した後に、当タスクを最初のセルから再度実行して必要なパラメータ実験を用意してください。\n"
    ]
   },
   {
@@ -198,9 +172,11 @@
     "try:\n",
     "    if is_activation:\n",
     "        if 'dir_creation_completed' in locals() and dir_creation_completed==True:\n",
-    "            print(\"手順2-3が実行済みですので、手順2-2を実行いただけません。パラメータ実験名の入力を誤った場合は、以降の全てのセルを最後まで実行した後に、当タスクを最初のセルから再度実行して必要なパラメータ実験を用意してください。\")\n",
+    "            print(\"手順2-2が実行済みですので、手順2-1を実行いただけません。パラメータ実験名の入力を誤った場合は、以降の全てのセルを最後まで実行した後に、当タスクを最初のセルから再度実行して必要なパラメータ実験を用意してください。\")\n",
     "        else:\n",
     "            # GINサーバのものに合わせたバリデーションルールを設定\n",
+    "            %store -r EXPERIMENT_TITLE\n",
+    "            experiment_path = '/home/jovyan/experiments/' + EXPERIMENT_TITLE\n",
     "            validation = re.compile(r'^[a-zA-Z0-9\\-_.]{1,50}$')\n",
     "\n",
     "            print('作成したいパラメータ実験名を50文字以内, 英数字、および\"-\", \"_\", \".\"で入力してください。')\n",
@@ -240,7 +216,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2-3. 入力したパラメータ実験名でディレクトリを用意する"
+    "### 2-2. 入力したパラメータ実験名でディレクトリを用意する\n",
+    "\n",
+    "パラメータ実験用のディレクトリを実験パッケージに作成します。"
    ]
   },
   {
@@ -249,17 +227,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "from IPython.display import clear_output\n",
+    "\n",
     "try:\n",
     "    if is_activation:\n",
     "        if 'dir_creation_completed' in locals() and dir_creation_completed==True:\n",
-    "            print(\"手順2-3はすでに実行済みです。次の処理にお進みください。\")\n",
+    "            print(\"手順2-2はすでに実行済みです。次の処理にお進みください。\")\n",
     "        else:\n",
+    "            # /home/jovyan 配下に移動する\n",
+    "            os.chdir(os.environ['HOME'])\n",
+    "\n",
+    "            # ディレクトリを追加する\n",
+    "            !cp -r ~/WORKFLOWS/PACKAGE/scheme/$scheme_name/parameter $experiment_path\n",
+    "            \n",
     "            # 該当実験パッケージを特定させるため、環境変数EXPERIMENT_TITLEに実験パッケージ名を設定\n",
     "            PARAMEXP_TITLE = paramexp_title\n",
     "            %store PARAMEXP_TITLE\n",
     "            clear_output()\n",
-    "\n",
+    "            \n",
     "            # 実験パッケージの直下に移動\n",
     "            os.chdir(experiment_path)\n",
     "\n",
@@ -267,6 +253,7 @@
     "            shutil.move('parameter', paramexp_title)\n",
     "            dir_creation_completed = True\n",
     "            print('入力したパラメータ実験名「' + paramexp_title + '」でディレクトリを用意しました。')\n",
+    "            \n",
     "    else:\n",
     "        print(\"本タスクの対象外です。以下のリンクから実験フロートップページに戻ってください。\")\n",
     "        display(HTML(\"<a href='../experiment.ipynb'>実験フロートップページに遷移する</a>\"))\n",


### PR DESCRIPTION
# PULL REQUEST

## Background

* [ユーザビリティ指摘事項の項番112](https://ivis.backlog.com/view/NII_DG-81)

## Main Points of Modification

* パラメータ実験用ディレクトリを用意するタスクで、処理の順序を修正しました。
  * これまで
    * 2-1. フォルダ作成　⇒　2.2. パラメータ実験名決定　⇒　2.3. フォルダ名を入力値で更新
  * 修正後
    * 2-1. パラメータ実験名決定　⇒　2-2. 入力値でパラメータ実験用ディレクトリを用意

## Test

* コード付帯機能で、「パラメータ実験用のディレクトリを追加する」を実行し、以下を確認しました。
  * 複数回タスクを実行しても正常終了すること
  * 手順2-2以降が未実行な状態で、手順2-1を再実行するとパラメータ実験名が再入力できること。
  * 手順2-2が実行済の状態で、手順2-1を再実行すると、手順2-2実行済なので再実行できない旨が表示されること。

## Viewpoint for Review

* 上記のテスト観点+タスクのマニュアルが適切であること。

## Supplementary Information


*
## ToDo

*
