### PR TITLE
git annex infoに半角スペースの適応

### DIFF
--- a/EX-WORKFLOWS/prepare_from_repository.ipynb
+++ b/EX-WORKFLOWS/prepare_from_repository.ipynb
@@ -483,7 +483,7 @@
     "for i in range(len(column)):\n",
     "    panel_type = str(type(column[i]))\n",
     "    if 'TextInput' in panel_type:\n",
-    "        cmd = package_path + '/' + column[i].name\n",
+    "        cmd = '\"{}/{}\"'.format(package_path, column[i].name)\n",
     "        annex_key = !git annex info $cmd | grep key\n",
     "        if 'URL' in annex_key[0].split('-')[0]:\n",
     "            # If the file entity is located on the Internet, such as S3.\n",


### PR DESCRIPTION
# PULL REQUEST

## Background

他リポジトリからデータ取得時、半角スペースがあるパスでgit annex infoが正常に動かないかった。

## Main Points of Modification

* パスの文字列をダブルクォーテーションで囲みgit annex infoに引数を渡すように修正した。

## Test

* 半角スペース有りのパスでリンクを作成することを確認した。
![image](https://github.com/NII-DG/workflow-template/assets/96706614/dd0351cc-7ddf-44dc-9d4b-21d3f855cf25)
![image](https://github.com/NII-DG/workflow-template/assets/96706614/f1aa8fbb-a46c-483d-86ae-ee1b93670e38)
![image](https://github.com/NII-DG/workflow-template/assets/96706614/3215587a-b76a-41c7-9a4f-a624e5110163)
* GIN-forkで同期していることを確認した。 
![image](https://github.com/NII-DG/workflow-template/assets/96706614/5675f91b-a3ef-46d7-8dc9-5934e260e247)



