### PR TITLE
研究・実験トップページの共通メニューの選択肢候補の変更

### DIFF
--- a/nb_libs/utils/form/menu.py
+++ b/nb_libs/utils/form/menu.py
@@ -29,6 +29,10 @@ def dg_menu(type='research'):
         menu_option[msg_mod.get('menu', 'trans_experiment_top')] = 5
     elif type == 'conflict':
         menu_option[msg_mod.get('menu', 'show_name')] = 4
+    elif type == 'research_top':
+        menu_option[msg_mod.get('menu', 'show_name_only_res')] = 2
+    elif type == 'experiment_top':
+        menu_option[msg_mod.get('menu', 'show_name')] = 4
 
     menu_option[msg_mod.get('menu', 'trans_gin')] = 6
 

--- a/notebooks/experiment/experiment.ipynb
+++ b/notebooks/experiment/experiment.ipynb
@@ -72,7 +72,7 @@
     "import sys\n",
     "sys.path.append(\"../..\")\n",
     "from nb_libs.utils.form import menu\n",
-    "menu.dg_menu('experiment')"
+    "menu.dg_menu('experiment_top')"
    ]
   },
   {

--- a/notebooks/research/base_FLOW.ipynb
+++ b/notebooks/research/base_FLOW.ipynb
@@ -71,7 +71,7 @@
     "import sys\n",
     "sys.path.append(\"../..\")\n",
     "from nb_libs.utils.form import menu\n",
-    "menu.dg_menu('research')"
+    "menu.dg_menu('research_top')"
    ]
   },
   {


### PR DESCRIPTION
# PULL REQUEST

## Background

・研究フロートップページの共通メニューに「研究フロートップページへ遷移する」のメニューがある
・実験フロートップページの共通メニューに「実験フロートップページへ遷移する」のメニューがある
同一ページに遷移するボタンは表示しなくてもよいのでは。

## Main Points of Modification

1. 研究トップページの共通メニュでは、研究トップページ遷移の選択肢を表示しない。
2. 実験トップページの共通メニュでは、実験トップページ遷移の選択肢を表示しない。

## Test

jupyter環境で変更されているか確認した。

* 研究トップページ
![image](https://github.com/NII-DG/workflow-template/assets/96706614/0316ed9d-19b2-4b93-ab38-da6d3d5d81bb)

* その他、研究タスク
![image](https://github.com/NII-DG/workflow-template/assets/96706614/548026c2-65cc-4c04-9131-176c6b5ddc74)

* 実験トップページ
![image](https://github.com/NII-DG/workflow-template/assets/96706614/83e9fbf8-c574-40f0-a34c-237afa56d53d)

* その他、実験タスク
![image](https://github.com/NII-DG/workflow-template/assets/96706614/4cc91e38-7486-4ece-9d52-76dd937598ed)

